### PR TITLE
🚀 5단계 - 동시성 확장하기

### DIFF
--- a/tomcat/src/main/java/jakarta/AbstractController.java
+++ b/tomcat/src/main/java/jakarta/AbstractController.java
@@ -7,14 +7,16 @@ public abstract class AbstractController implements Controller {
 
     @Override
     public void service(HttpRequest httpRequest, HttpResponse httpResponse) throws Exception {
-        var httpServletResponse = new HttpServletResponse();
 
         if (httpRequest.isGet()) {
+            var httpServletResponse = new HttpServletResponse();
             doGet(HttpServletRequest.from(httpRequest), httpServletResponse);
             httpResponse.update(httpServletResponse);
             return;
         }
+
         if (httpRequest.isPost()) {
+            var httpServletResponse = new HttpServletResponse();
             doPost(HttpServletRequest.from(httpRequest), httpServletResponse);
             httpResponse.update(httpServletResponse);
             return;

--- a/tomcat/src/main/java/jakarta/HttpServletRequest.java
+++ b/tomcat/src/main/java/jakarta/HttpServletRequest.java
@@ -36,7 +36,7 @@ public class HttpServletRequest {
     }
 
     public Session getSession(boolean create) {
-        if (create) {
+        if (this.session == null && create) {
             this.session = new Session(UUID.randomUUID().toString());
         }
         return this.session;

--- a/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
+++ b/tomcat/src/main/java/org/apache/catalina/connector/Connector.java
@@ -8,22 +8,31 @@ import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 public class Connector implements Runnable {
 
     private static final Logger log = LoggerFactory.getLogger(Connector.class);
 
     private static final int DEFAULT_PORT = 8080;
-    private static final int DEFAULT_ACCEPT_COUNT = 100;
+    private static final int DEFAULT_LIMIT_ACCEPT_COUNT = 100;
+    private static final int DEFAULT_MAX_THREADS = 250;
+    private static ExecutorService es;
 
     private final ServerSocket serverSocket;
     private boolean stopped;
 
     public Connector() {
-        this(DEFAULT_PORT, DEFAULT_ACCEPT_COUNT);
+        this(DEFAULT_PORT, DEFAULT_LIMIT_ACCEPT_COUNT, DEFAULT_MAX_THREADS);
     }
 
     public Connector(final int port, final int acceptCount) {
+        this(port, acceptCount, DEFAULT_MAX_THREADS);
+    }
+
+    public Connector(final int port, final int acceptCount, final int maxThreads) {
+        es = Executors.newFixedThreadPool(checkMaxThreads(maxThreads));
         this.serverSocket = createServerSocket(port, acceptCount);
         this.stopped = false;
     }
@@ -67,7 +76,7 @@ public class Connector implements Runnable {
             return;
         }
         var processor = new Http11Processor(connection);
-        new Thread(processor).start();
+        es.execute(processor);
     }
 
     public void stop() {
@@ -90,6 +99,10 @@ public class Connector implements Runnable {
     }
 
     private int checkAcceptCount(final int acceptCount) {
-        return Math.max(acceptCount, DEFAULT_ACCEPT_COUNT);
+        return Math.min(acceptCount, DEFAULT_LIMIT_ACCEPT_COUNT);
+    }
+
+    private int checkMaxThreads(int maxThreads) {
+        return Math.max(maxThreads, DEFAULT_MAX_THREADS);
     }
 }

--- a/tomcat/src/main/java/org/apache/coyote/http11/ApplicationRequestHandler.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/ApplicationRequestHandler.java
@@ -17,7 +17,7 @@ public class ApplicationRequestHandler implements RequestHandler {
     );
 
     @Override
-    public HttpResponse service(HttpRequest httpRequest) throws Exception {
+    public HttpResponse service(HttpRequest httpRequest){
         final var requestLine = httpRequest.getRequestLine();
 
         if ("/".equals(requestLine.getPath())) {
@@ -28,7 +28,11 @@ public class ApplicationRequestHandler implements RequestHandler {
         final var controller = SERVLET_MAPPING.get(requestLine.getPath());
         final var httpResponse = new HttpResponse(new StatusLine(requestLine.getHttpProtocol()), httpRequest.getRequestHeaders().host());
 
-        controller.service(httpRequest, httpResponse);
+        try {
+            controller.service(httpRequest, httpResponse);
+        } catch (Exception e) {
+            httpResponse.setError(e.getCause(), HttpStatusCode.INTERNAL_SERVER_ERROR);
+        }
 
         return httpResponse;
     }

--- a/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/Http11Processor.java
@@ -45,9 +45,6 @@ public class Http11Processor implements Runnable, Processor {
             outputStream.flush();
         } catch (IOException | UncheckedServletException | HttpRequestLineInvalidException e) {
             log.error(e.getMessage(), e);
-        } catch (Exception e) {
-            throw new RuntimeException(e);
         }
     }
-
 }

--- a/tomcat/src/main/java/org/apache/coyote/http11/RequestHandler.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/RequestHandler.java
@@ -6,5 +6,5 @@ import org.apache.coyote.http11.response.HttpResponse;
 
 
 public interface RequestHandler {
-    HttpResponse service(HttpRequest httpRequest) throws Exception;
+    HttpResponse service(HttpRequest httpRequest);
 }

--- a/tomcat/src/main/java/org/apache/coyote/http11/constants/HttpFormat.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/constants/HttpFormat.java
@@ -5,11 +5,11 @@ public final class HttpFormat {
     private HttpFormat() {
     }
 
-    public static final String SP = " ";
+    public static final String SPACE = " ";
     public static final String CRLF = "\r\n";
 
     public static String headerFieldValue(String key, String value) {
-        return key + HEADERS.FIELD_VALUE_DELIMITER + value + SP + CRLF;
+        return key + HEADERS.FIELD_VALUE_DELIMITER + value + SPACE + CRLF;
 
     }
     public static class HEADERS {

--- a/tomcat/src/main/java/org/apache/coyote/http11/response/HttpResponse.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/response/HttpResponse.java
@@ -10,6 +10,7 @@ public class HttpResponse {
     private String host;
     private HttpResponseHeaders httpResponseHeaders = new HttpResponseHeaders();
     private MessageBody messageBody;
+    private Throwable cause;
 
     public HttpResponse(StatusLine statusLine, HttpResponseHeaders httpResponseHeaders, MessageBody messageBody) {
         this.statusLine = statusLine;
@@ -62,4 +63,8 @@ public class HttpResponse {
     }
 
 
+    public void setError(Throwable cause, HttpStatusCode httpStatusCode) {
+        this.statusLine = new StatusLine(statusLine.protocol(), httpStatusCode);
+        this.cause = cause;
+    }
 }

--- a/tomcat/src/main/java/org/apache/coyote/http11/response/StatusLine.java
+++ b/tomcat/src/main/java/org/apache/coyote/http11/response/StatusLine.java
@@ -13,6 +13,6 @@ public record StatusLine(HttpProtocol protocol, HttpStatusCode statusCode) {
     }
 
     public String toMessage() {
-        return protocol.description() + HttpFormat.SP + statusCode.getCode() + HttpFormat.SP + statusCode.getDescription() + HttpFormat.SP + HttpFormat.CRLF;
+        return protocol.description() + HttpFormat.SPACE + statusCode.getCode() + HttpFormat.SPACE + statusCode.getDescription() + HttpFormat.SPACE + HttpFormat.CRLF;
     }
 }

--- a/tomcat/src/test/java/org/apache/catalina/connector/ConnectorTest.java
+++ b/tomcat/src/test/java/org/apache/catalina/connector/ConnectorTest.java
@@ -9,6 +9,8 @@ import java.io.IOException;
 import java.io.InputStreamReader;
 import java.net.URL;
 import java.net.URLConnection;
+import java.time.LocalDateTime;
+import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 
@@ -29,6 +31,35 @@ class ConnectorTest {
                         .isThrownBy(this::urlConnectionReader);
     }
 
+    @Test
+    @DisplayName("동시 request 처리 테스트")
+    public void executorStudyTest() throws InterruptedException {
+        Connector con = new Connector(8080, 100);
+        new Thread(() -> {
+            con.start();
+            con.run();
+        }).start();
+
+        final int concurrentRequest = 50;
+        CountDownLatch latch = new CountDownLatch(concurrentRequest);
+        ExecutorService es = Executors.newFixedThreadPool(concurrentRequest);
+        for (int i = 0; i < concurrentRequest; i++) {
+            es.submit(() -> {
+                for (int j = 0; j < 10; j++) {
+                    try {
+                        this.urlConnectionReader();
+                    } catch (IOException e) {
+                        throw new RuntimeException(e);
+                    }
+                }
+                latch.countDown();
+            });
+
+        }
+        latch.await();
+    }
+
+
 
     public void urlConnectionReader() throws IOException {
         URL url = new URL("http://localhost:8080/index.html");
@@ -38,7 +69,7 @@ class ConnectorTest {
             String inputLine;
 
             while ((inputLine = in.readLine()) != null)
-                System.out.println(inputLine);
+                System.out.println(LocalDateTime.now() );
         }
     }
 }


### PR DESCRIPTION
안녕하세요 선흠님!

마지막 리뷰 잘 부탁드립니다!

피드백 주신 부분중에 Response 생성 로직 공통화 부분 ([링크](https://github.com/next-step/java-http/pull/64#discussion_r1685463385))은
저는 `Response`가 가변 객체여서 정적 팩토리 메서드로 또다시 인스턴스를 생성하는 것보단 `setter`가 낫지 않나 판단했습니다!

tomcat의 메서드 시그니처인 doPost(HttpServletRequest request, HttpServletResponse response)를 따라하려고 보니 
가변 객체를 사용하게 되었는데요, 
작업하면서 왜 `HttpServletResponse doPost(HttpServletRequest request)`처럼 메서드 리턴타입을 Response로 하지 않았을까 
의문이 들긴 했습니다. 

제 생각은 Response에 초기화할 속성이 많아서인가? 였는데 톰캣 구현 코드를 보니 또 속성이 많다기 보다는
HttpServletResponse 확장 클래스가 많네요!

선흠님의 생각도 궁금합니다!